### PR TITLE
docs: fix release docs for etcd-backup-s3 and etcd-backup-pvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ Velero allows you to:
 - migrate cluster resources to other clusters
 - replicate your production environment to development and testing environment.
 
-ETCD backupper allows you to:
+ETCD backup allows you to:
 
-- snapshot your ETCD cluster
+- snapshot your ETCD cluster on an S3 bucket
+- snapshot your ETCD cluster on an already provisioned PVC
 
 Together with Velero, Velero Node Agent allows you to:
 

--- a/docs/releases/v3.1.0.md
+++ b/docs/releases/v3.1.0.md
@@ -4,7 +4,10 @@ Welcome to the latest release of the `DR` module of [`Kubernetes Fury Distributi
 
 This latest release upgrades the components in the module to their latest stable release.
 
-In this release we're adding a new package, [`etcd-backup-s3`](../../katalog/etcd-backup-s3/README.md), which handles the automated snapshot of ETCD and pushes it to a remote S3-compatible object storage (like Minio, AWS S3).
+In this release we're adding two new packages:
+- [`etcd-backup-s3`](../../katalog/etcd-backup-s3/README.md), which handles the automated snapshot of ETCD and pushes it to a remote S3-compatible object storage (like Minio, AWS S3).
+
+- [`etcd-backup-pvc`](../../katalog/etcd-backup-pvc/README.md), which handles the automated snapshot of ETCD and saves it to an already provisioned PersistentVolumeClaim.
 
 ## Component Images 🚢
 
@@ -65,4 +68,10 @@ kustomize build katalog/velero/velero-on-prem | kubectl apply -f -
 
 3. (Optional) Install `etcd-backup-s3`: from the `katalog/etcd-backup-s3` folder edit the file `rclone/rclone.conf`, adjust the `kustomization.yaml` and then run the following
 ```bash
-k kustomize build | k apply -f -`
+k kustomize build | k apply -f -
+```
+
+4. (Optional) Install `etcd-backup-pvc`: from the `katalog/etcd-backup-pvc` folder, adjust the `kustomization.yaml` and then run the following
+```bash
+k kustomize build | k apply -f -
+```


### PR DESCRIPTION
### Summary 💡

Fix the release docs to include both `etcd-backup-s3` and `etcd-backup-pvc`.

### Description 📝

During the release I figured that the docs for `etcd-backup-s3` and `etcd-backup-pvc` were missing. This PR readds them.

### Breaking Changes 💔
None.
<!--
If this PR introduces Breaking Changes, please include all the relevant information:
- What is changing
- What should the process for updating be
- Include examples if you can
-->

### Tests performed 🧪
None.
<!--
Create a checklist with all the tests that you performed on your changes, being manual or automated.
If you are opening a Draft PR, you can use the checklist to track the tests that you want to do and mark them once you
have performed them.
Example:

- [ ] Tested the change with KFD version X.Y.Z
- [ ] Tested an upgrade from the previous version X
-->

### Future work 🔧
None.
<!--
If there's any future work that could improve or extend on the work you've done in this PR you can mention it so
this PR can be used as context for that.
-->