### PR TITLE
chore: rename Fury to SIGHUP Distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
 <!-- markdownlint-disable MD033 -->
 <h1>
-    <img src="https://github.com/sighupio/fury-distribution/blob/main/docs/assets/fury-epta-white.png?raw=true" align="left" width="90" style="margin-right: 15px"/>
-    Kubernetes Fury Disaster Recovery
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/sighupio/distribution/refs/heads/main/docs/assets/white-logo.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/sighupio/distribution/refs/heads/main/docs/assets/black-logo.png">
+  <img alt="Shows a black logo in light color mode and a white one in dark color mode." src="https://raw.githubusercontent.com/sighupio/distribution/refs/heads/main/docs/assets/white-logo.png">
+</picture><br/>
+  SIGHUP Distribution <br/> Disaster Recovery
 </h1>
 <!-- markdownlint-enable MD033 -->
 
 ![Release](https://img.shields.io/badge/Latest%20Release-v3.1.0-blue)
-![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-dr?label=License)
+![License](https://img.shields.io/github/license/sighupio/module-dr?label=License)
 [![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)](https://kubernetes.slack.com/archives/C0154HYTAQH)
 
-<!-- <KFD-DOCS> -->
+<!-- <SKD-DOCS> -->
 
-**Kubernetes Fury Disaster Recovery (DR)** implements backups and disaster recovery for the [Kubernetes Fury Distribution (KFD)][kfd-repo] using [Velero][velero-page].
+**SIGHUP Distribution Disaster Recovery (DR)** implements backups and disaster recovery for the [SIGHUP Distribution (SKD)][skd-repo] using [Velero][velero-page].
 
-If you are new to KFD please refer to the [official documentation][kfd-docs] on how to get started with KFD.
+If you are new to SKD please refer to the [official documentation][skd-docs] on how to get started with SKD.
 
 ## Overview
 
-**Kubernetes Fury DR** module is based on [Velero][velero-page], [Velero Node Agent][velero-node-agent-page] and etcd backup ([S3][etcd-backup-s3-link]/[PVC][etcd-backup-pvc-link]).
+**SIGHUP Distribution DR** module is based on [Velero][velero-page], [Velero Node Agent][velero-node-agent-page] and etcd backup ([S3][etcd-backup-s3-link]/[PVC][etcd-backup-pvc-link]).
 
 Velero allows you to:
 
@@ -44,7 +48,7 @@ The module contains also velero plugins to natively integrate with Velero with d
 
 ## Packages
 
-Kubernetes Fury DR provides the following packages:
+SIGHUP Distribution DR provides the following packages:
 
 | Package                                    | Version     | Description                                                                                                     |
 | ------------------------------------------ | ----------- | --------------------------------------------------------------------------------------------------------------- |
@@ -90,7 +94,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 ## Usage
 
-**Kubernetes Fury DR**'s Velero deployment depends on the environment.
+**SIGHUP Distribution DR**'s Velero deployment depends on the environment.
 
 | Environment                               | Storage Backend      | Velero Plugin                                   | Terraform Module                     |
 | ----------------------------------------- | -------------------- | ----------------------------------------------- | ------------------------------------ |
@@ -99,7 +103,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 | [Velero on Azure](#velero-on-azure)       | AZ Storage Container | [velero-azure](katalog/velero/velero-azure)     | [azure-velero](modules/azure-velero) |
 | [Velero on-premises](#velero-on-premises) | MinIo                | [velero-on-prem](katalog/velero/velero-on-prem) | `/`                                  |
 
-**Kubernetes Fury DR**'s etcd-backup deployment depends on the final location of the backups.
+**SIGHUP Distribution DR**'s etcd-backup deployment depends on the final location of the backups.
 | Package                                   | Storage Location        |
 | ----------------------------------------- | ----------------------- |
 | [etcd-backup-s3](#etcd-backup-s3)         | S3 Bucket               |
@@ -110,7 +114,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 | Tool                        | Version    | Description                                                                                                                                                    |
 | --------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [furyctl][furyctl-repo]     | `>=0.25.0` | The recommended tool to download and manage KFD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
+| [furyctl][furyctl-repo]     | `>=0.25.0` | The recommended tool to download and manage SKD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
 | [kustomize][kustomize-repo] | `>=3.5.3`  | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
 | [terraform][terraform-page] | `>=1.3`    | Additional infrastructure is deployed using `terraform`.                                                                                                       |
 
@@ -159,7 +163,7 @@ module "velero" {
 
 > More information on modules inputs can be found in the [aws-velero](modules/aws-velero) module documentation
 >
-> [Here][kfd-velero-aws-example] you can find an example designed to create all necessary cloud resources for Velero on AWS.
+> [Here][skd-velero-aws-example] you can find an example designed to create all necessary cloud resources for Velero on AWS.
 
 5. Define a `kustomization.yaml` that includes the downloaded resources.
 
@@ -223,7 +227,7 @@ module "velero" {
 
 > More information on modules inputs can be found in the [gcp-velero](modules/gcp-velero) module documentation
 >
-> [Here][kfd-velero-gcp-example] you can find an example designed to create all necessary cloud resources for Velero on GCP.
+> [Here][skd-velero-gcp-example] you can find an example designed to create all necessary cloud resources for Velero on GCP.
 
 5. Define a `kustomization.yaml` that includes the downloaded resources.
 
@@ -284,7 +288,7 @@ module "velero" {
 
 > More information on modules inputs can be found in the [azure-velero](modules/azure-velero) module documentation
 >
-> [Here][kfd-velero-azure-example] you can find an example designed to create all necessary cloud resources for Velero on Azure.
+> [Here][skd-velero-azure-example] you can find an example designed to create all necessary cloud resources for Velero on Azure.
 
 5. Define a `kustomization.yaml` that includes the downloaded resources.
 
@@ -303,7 +307,7 @@ kustomize build . | kubectl apply -f -
 
 ### Velero on-premises
 
-[velero-on-prem][kfd-velero-on-prem] deploys a [MinIO][minio-page] in-cluster instance as an object storage backend for Velero.
+[velero-on-prem][skd-velero-on-prem] deploys a [MinIO][minio-page] in-cluster instance as an object storage backend for Velero.
 
 Please note that the MinIO server is running in the same cluster that is being backed up.
 
@@ -359,23 +363,23 @@ In order to deploy `etcd-backup-pvc`, please refer to the [package's README.md][
 [velero-node-agent-page]: https://velero.io/docs/v1.12/file-system-backup/
 [minio-page]: https://min.io/
 [terraform-page]: https://www.terraform.io/
-[kfd-repo]: https://github.com/sighupio/fury-distribution
+[skd-repo]: https://github.com/sighupio/distribution
 [furyctl-repo]: https://github.com/sighupio/furyctl
 [kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
 [velero-gcp-plugin-repo]: https://github.com/vmware-tanzu/velero-plugin-for-gcp
 [velero-aws-plugin-repo]: https://github.com/vmware-tanzu/velero-plugin-for-aws
 [velero-azure-plugin-repo]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure
 [velero-gcp-plugin-repo-permissions]: https://github.com/vmware-tanzu/velero-plugin-for-gcp#set-permissions-for-velero
-[kfd-velero-gcp-example]: https://github.com/sighupio/fury-kubernetes-dr/tree/main/examples/gcp-examples/main.tf
-[kfd-velero-aws-example]: https://github.com/sighupio/fury-kubernetes-dr/tree/main/examples/aws-examples/main.tf
-[kfd-velero-azure-example]: https://github.com/sighupio/fury-kubernetes-dr/tree/main/examples/azure-examples/main.tf
-[kfd-velero-on-prem]: https://github.com/sighupio/fury-kubernetes-dr/tree/main/katalog/velero/velero-on-prem
+[skd-velero-gcp-example]: https://github.com/sighupio/module-dr/tree/main/examples/gcp-examples/main.tf
+[skd-velero-aws-example]: https://github.com/sighupio/module-dr/tree/main/examples/aws-examples/main.tf
+[skd-velero-azure-example]: https://github.com/sighupio/module-dr/tree/main/examples/azure-examples/main.tf
+[skd-velero-on-prem]: https://github.com/sighupio/module-dr/tree/main/katalog/velero/velero-on-prem
 [aws-docs-iam-roles]: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
-[kfd-docs]: https://docs.kubernetesfury.com/docs/distribution/
-[compatibility-matrix]: https://github.com/sighupio/fury-kubernetes-dr/blob/master/docs/COMPATIBILITY_MATRIX.md
-[etcd-backup-s3-link]: https://github.com/sighupio/fury-kubernetes-dr/blob/master/katalog/etcd-backup-s3/README.md
-[etcd-backup-pvc-link]: https://github.com/sighupio/fury-kubernetes-dr/blob/master/katalog/etcd-backup-pvc/README.md
-<!-- </KFD-DOCS> -->
+[skd-docs]: https://docs.sighup.io/
+[compatibility-matrix]: https://github.com/sighupio/module-dr/blob/master/docs/COMPATIBILITY_MATRIX.md
+[etcd-backup-s3-link]: https://github.com/sighupio/module-dr/blob/master/katalog/etcd-backup-s3/README.md
+[etcd-backup-pvc-link]: https://github.com/sighupio/module-dr/blob/master/katalog/etcd-backup-pvc/README.md
+<!-- </SKD-DOCS> -->
 
 <!-- <FOOTER> -->
 
@@ -385,7 +389,7 @@ Before contributing, please read first the [Contributing Guidelines](docs/CONTRI
 
 ### Reporting Issues
 
-In case you experience any problem with the module, please [open a new issue](https://github.com/sighupio/fury-kubernetes-dr/issues/new/choose).
+In case you experience any problem with the module, please [open a new issue](https://github.com/sighupio/module-dr/issues/new/choose).
 
 ## License
 

--- a/docs/releases/v1.10.0.md
+++ b/docs/releases/v1.10.0.md
@@ -1,6 +1,7 @@
 # Disaster recovery Core Module Release 1.10.0
 
-Welcome to the latest release of the `DR` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `dr` module of [`SIGHUP
+Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This latest release upgrades the components in the module to its latest stable release along with adding support for Kubernetes release `v1.24.0`.
 

--- a/docs/releases/v1.10.1.md
+++ b/docs/releases/v1.10.1.md
@@ -1,6 +1,7 @@
 # Disaster recovery Core Module Release 1.10.1
 
-Welcome to the latest release of the `DR` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `dr` module of [`SIGHUP
+Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This is a bugfix release to include needed ouput in the Terraform modules.
 
@@ -16,7 +17,7 @@ This is a bugfix release to include needed ouput in the Terraform modules.
 
 > Please refer to the individual release notes to get a detailed information on each release.
 
-ℹ️ If you are coming from version `v1.9.x` or before, please read the [release notes for v1.10.0](https://github.com/sighupio/fury-kubernetes-dr/releases/tag/v1.10.0) first.
+ℹ️ If you are coming from version `v1.9.x` or before, please read the [release notes for v1.10.0](https://github.com/sighupio/module-dr/releases/tag/v1.10.0) first.
 
 ## Features 💥
 

--- a/docs/releases/v1.11.0.md
+++ b/docs/releases/v1.11.0.md
@@ -1,6 +1,7 @@
 # Disaster recovery Core Module Release 1.11.0
 
-Welcome to the latest release of the `DR` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `dr` module of [`SIGHUP
+Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This latest release upgrades the components in the module to its latest stable release along with adding support for Kubernetes release `v1.25`.
 

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -47,7 +47,7 @@ $ curl -L https://github.com/heptio/velero/releases/download/v0.11.0/velero-v0.1
 $ tar xvf velero-v0.11.0-${OS}-${ARCH}.tar.gz
 
 # Create the prerequisite CRDs
-$ kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-dr/v1.2.0/katalog/velero/base/crds.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/sighupio/module-dr/v1.2.0/katalog/velero/base/crds.yaml
 
 # Download and unpack the crd-migrator tool
 $ curl -L https://github.com/vmware/crd-migration-tool/releases/download/v1.0.0/crd-migration-tool-v1.0.0-${OS}-${ARCH}.tar.gz --output crd-migration-tool-v1.0.0-${OS}-${ARCH}.tar.gz

--- a/docs/releases/v1.5.0.md
+++ b/docs/releases/v1.5.0.md
@@ -1,6 +1,8 @@
 # Disaster Recovery Core Module version 1.5.0
 
-SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
+Welcome to the latest release of `dr` module of [`SIGHUP
+Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
+
 With the Kubernetes 1.19 release, it became the perfect time to start testing this module against this Kubernetes
 release. VMWare continues doing amazing work with Velero. This has become a standard to backup and restore
 Kubernetes' clusters. With the release of its latest release, we want to include the new release in this core module.

--- a/docs/releases/v1.6.0.md
+++ b/docs/releases/v1.6.0.md
@@ -1,6 +1,8 @@
 # Disaster Recovery Core Module version 1.6.0
 
-SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
+Welcome to the latest release of `dr` module of [`SIGHUP
+Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
+
 With the Kubernetes 1.20 release, it became the perfect time to start testing this module against this Kubernetes
 release. Minor works have been done in the AWS terraform module.
 

--- a/docs/releases/v1.7.0.md
+++ b/docs/releases/v1.7.0.md
@@ -1,6 +1,8 @@
 # Disaster Recovery Core Module version 1.7.0
 
-SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
+Welcome to the latest release of `dr` module of [`SIGHUP
+Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
+
 With the Kubernetes 1.21 release, it became the perfect time to start testing this module against this Kubernetes
 release.
 

--- a/docs/releases/v1.8.0.md
+++ b/docs/releases/v1.8.0.md
@@ -1,20 +1,21 @@
 # Disaster Recovery Core Module version 1.8.0
 
-`fury-kubernetes-dr` is part of the SIGHUP maintained [Kubernetes Fury Distribution](https://github.com/sighupio/fury-distribution). The module ships disastor recovery tools and utilities to be deployed on the Kubernetes cluster based on Velero. Team SIGHUP makes it a priority to maintain these modules in compliance with CNCF and with all the latest features from upstream.
+Welcome to the latest release of `dr` module of [`SIGHUP
+Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
-This release introduces the support for Kubernetes runtime `1.22` and drops support for `1.18`. Refer the [Compatibility Matrix](https://github.com/sighupio/fury-kubernetes-dr#compatibility) for more.
+This release introduces the support for Kubernetes runtime `1.22` and drops support for `1.18`. Refer the [Compatibility Matrix](https://github.com/sighupio/module-dr#compatibility) for more.
 
 ## Changelog
 
 ### Breaking Changes
 > None
 ### Features
-- [#34](https://github.com/sighupio/fury-kubernetes-dr/pull/34) Supporting e2e test for 1.22.0 kubernetes
-- [#35](https://github.com/sighupio/fury-kubernetes-dr/pull/35) Adapting Velero CRD to use `apiextensions.k8s.io/v1` apiVersion to support k8s 1.22
-- [#33](https://github.com/sighupio/fury-kubernetes-dr/pull/33) Upgrading Velero from v1.6.0 to [v1.6.3](https://github.com/vmware-tanzu/velero/releases/tag/v1.6.3)
-- [#33](https://github.com/sighupio/fury-kubernetes-dr/pull/33) Upgrading velero-aws-plugin from v1.2.0 to [v1.2.1](https://github.com/vmware-tanzu/velero-plugin-for-aws/releases/tag/v1.2.1)
-- [#33](https://github.com/sighupio/fury-kubernetes-dr/pull/33) Upgrading velero-plugin-for-microsoft-azure from v1.2.0 to [v1.2.1](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/releases/tag/v1.2.1)
-- [#33](https://github.com/sighupio/fury-kubernetes-dr/pull/33) Upgrading velero-plugin-for-gcp from v1.2.0 to [v1.2.1](https://github.com/vmware-tanzu/velero-plugin-for-gcp/releases/tag/v1.2.1)
+- [#34](https://github.com/sighupio/module-dr/pull/34) Supporting e2e test for 1.22.0 kubernetes
+- [#35](https://github.com/sighupio/module-dr/pull/35) Adapting Velero CRD to use `apiextensions.k8s.io/v1` apiVersion to support k8s 1.22
+- [#33](https://github.com/sighupio/module-dr/pull/33) Upgrading Velero from v1.6.0 to [v1.6.3](https://github.com/vmware-tanzu/velero/releases/tag/v1.6.3)
+- [#33](https://github.com/sighupio/module-dr/pull/33) Upgrading velero-aws-plugin from v1.2.0 to [v1.2.1](https://github.com/vmware-tanzu/velero-plugin-for-aws/releases/tag/v1.2.1)
+- [#33](https://github.com/sighupio/module-dr/pull/33) Upgrading velero-plugin-for-microsoft-azure from v1.2.0 to [v1.2.1](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/releases/tag/v1.2.1)
+- [#33](https://github.com/sighupio/module-dr/pull/33) Upgrading velero-plugin-for-gcp from v1.2.0 to [v1.2.1](https://github.com/vmware-tanzu/velero-plugin-for-gcp/releases/tag/v1.2.1)
 ### Bug Fixes
 > None
 ### Security Fixes

--- a/docs/releases/v1.9.0.md
+++ b/docs/releases/v1.9.0.md
@@ -2,9 +2,8 @@
 
 :x: This release contains issues, please use the version `1.9.2` instead.
 
-Welcome to the latest release of `dr` module of [`Kubernetes Fury
-Distribution`](https://github.com/sighupio/fury-distribution) maintained by team
-SIGHUP.
+Welcome to the latest release of `dr` module of [`SIGHUP
+Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This latest release is an attempt on upgrading the components in the module to
 its latest stable release along with adding the tech preview of the latest
@@ -30,14 +29,14 @@ kubernetes release `v1.23.0`.
 
 ## Breaking Changes 💔
 
-- [#39](https://github.com/sighupio/fury-kubernetes-opa/pull/39) Added Kubernetes labels to all the components of the module: Since `labels` are immutable fields in deployments, daemonsets, etc., this change requires a recreation of those resources.
+- [#39](https://github.com/sighupio/module-dr/pull/39) Added Kubernetes labels to all the components of the module: Since `labels` are immutable fields in deployments, daemonsets, etc., this change requires a recreation of those resources.
 
 ## Features 💥
 
-- [#38](https://github.com/sighupio/fury-kubernetes-opa/pull/38) Add makefile to DR module
-- [#40](https://github.com/sighupio/fury-kubernetes-opa/pull/40) Add JSON builder to DR module
-- [#41](https://github.com/sighupio/fury-kubernetes-opa/pull/41) Add 1.23 e2e-testing support for DR module
-- [#42](https://github.com/sighupio/fury-kubernetes-opa/pull/42) Upgrade velero images
+- [#38](https://github.com/sighupio/module-dr/pull/38) Add makefile to DR module
+- [#40](https://github.com/sighupio/module-dr/pull/40) Add JSON builder to DR module
+- [#41](https://github.com/sighupio/module-dr/pull/41) Add 1.23 e2e-testing support for DR module
+- [#42](https://github.com/sighupio/module-dr/pull/42) Upgrade velero images
 
 ## Update Guide 🦮
 

--- a/docs/releases/v1.9.1.md
+++ b/docs/releases/v1.9.1.md
@@ -2,14 +2,13 @@
 
 :x: This release contains issues, please use the version `1.9.2` instead.
 
-Welcome to the latest release of `dr` module of [`Kubernetes Fury
-Distribution`](https://github.com/sighupio/fury-distribution) maintained by team
-SIGHUP.
+Welcome to the latest release of `dr` module of [`SIGHUP
+Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This is a patch release with a documentation improvement and structure change.
 
 > 💡 Please refer the release notes of the minor version
-> [`v1.9.1`](https://github.com/sighupio/fury-kubernetes-dr/releases/tag/v1.9.1)
+> [`v1.9.1`](https://github.com/sighupio/module-dr/releases/tag/v1.9.1)
 > if you are upgrading from a version `< v1.9.0`
 
 ## Component Images 🚢
@@ -27,14 +26,14 @@ This is a patch release with a documentation improvement and structure change.
 
 ## Features 💥
 
-- [#44](https://github.com/sighupio/fury-kubernetes-dr/pull/44) Re-introduce IAM Roles for ServiceAccount support to aws-velero
+- [#44](https://github.com/sighupio/module-dr/pull/44) Re-introduce IAM Roles for ServiceAccount support to aws-velero
    ⚠ We recommend using `aws-velero` module in AWS instead of the module
    `eks-velero`. We are deprecating `eks-velero` as of this release, and from
    the next, it will be completely removed.
 
 ## Documentation 📕
 
-- [#43](https://github.com/sighupio/fury-kubernetes-dr/pulls/43) Improve
+- [#43](https://github.com/sighupio/module-dr/pulls/43) Improve
   and restructure the documentation of the dr module
 
 ## Update Guide 🦮

--- a/docs/releases/v1.9.2.md
+++ b/docs/releases/v1.9.2.md
@@ -1,8 +1,7 @@
 # Disaster recovery Core Module Release 1.9.2
 
-Welcome to the latest release of `dr` module of [`Kubernetes Fury
-Distribution`](https://github.com/sighupio/fury-distribution) maintained by team
-SIGHUP.
+Welcome to the latest release of `dr` module of [`SIGHUP
+Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This is a patch release reverts the commonLabels applied in `v1.9.0` because they break updating the module in the future.
 

--- a/docs/releases/v1.9.3.md
+++ b/docs/releases/v1.9.3.md
@@ -1,8 +1,7 @@
 # Disaster recovery Core Module Release 1.9.3
 
-Welcome to the latest release of `dr` module of [`Kubernetes Fury
-Distribution`](https://github.com/sighupio/fury-distribution) maintained by team
-SIGHUP.
+Welcome to the latest release of `dr` module of [`SIGHUP
+Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This is a patch release that fixes an issue on the [`aws-velero`](../../modules/aws-velero) Terraform module.
 
@@ -21,6 +20,6 @@ This is a patch release that fixes an issue on the [`aws-velero`](../../modules/
 
 ### Bug Fixes
 
-- [#48](https://github.com/sighupio/fury-kubernetes-dr/pull/48) Fix an issue
+- [#48](https://github.com/sighupio/module-dr/pull/48) Fix an issue
   with [`aws-velero`](../../modules/aws-velero) Terraform module and reintroduce
   Kustomize patches for Velero Deployment resource as Terraform output.

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -1,6 +1,6 @@
 # Disaster recovery Core Module Release 2.0.0
 
-Welcome to the latest release of the `DR` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of the `DR` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This latest release upgrades Terraform Modules in the module to Terraform >= 1.3.
 

--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -1,6 +1,6 @@
 # Disaster recovery Core Module Release 2.1.0
 
-Welcome to the latest release of the `DR` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of the `DR` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This latest release upgrades the components in the module to its latest stable release along with adding support for Kubernetes release `v1.26`.
 

--- a/docs/releases/v2.2.0.md
+++ b/docs/releases/v2.2.0.md
@@ -1,6 +1,6 @@
 # Disaster recovery Core Module Release 2.2.0
 
-Welcome to the latest release of the `DR` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of the `DR` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This latest release upgrades the components in the module to its latest stable release along with adding support for Kubernetes release `v1.27`.
 

--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -1,6 +1,6 @@
 # Disaster recovery Core Module Release 2.23.0
 
-Welcome to the latest release of the `DR` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of the `DR` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This latest release upgrades the components in the module to its latest stable release along with adding support for Kubernetes release `v1.28`.
 

--- a/docs/releases/v2.4.0.md
+++ b/docs/releases/v2.4.0.md
@@ -1,6 +1,6 @@
 # Disaster recovery Core Module Release 2.4.0
 
-Welcome to the latest release of the `DR` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of the `DR` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This latest release upgrades the components in the module to their latest stable release.
 It also removes `csi` plugin, because it's already merged into Velero itself.

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -1,6 +1,6 @@
 # Disaster recovery Core Module Release 3.0.0
 
-Welcome to the latest release of the `DR` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of the `DR` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This latest release upgrades the components in the module to their latest stable release, and it's considered a major release since we are changing the default backup method to kopia and enabling by default the EnableCSI feature.
 

--- a/docs/releases/v3.1.0.md
+++ b/docs/releases/v3.1.0.md
@@ -1,6 +1,6 @@
 # Disaster recovery Core Module Release 3.1.0
 
-Welcome to the latest release of the `DR` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of the `DR` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP by ReeVo.
 
 This latest release upgrades the components in the module to their latest stable release.
 

--- a/examples/registry-override/README.md
+++ b/examples/registry-override/README.md
@@ -2,4 +2,4 @@
 
 In this folder, you will find all the examples to override the images used in our `katalogs`.
 
-We host all the fury images on registry.sighup.io, but if you have your registry or mirror, you can override them and switch the source.
+We host all the SIGHUP Distribution images on registry.sighup.io, but if you have your registry or mirror, you can override them and switch the source.

--- a/katalog/etcd-backup-pvc/MAINTENANCE.md
+++ b/katalog/etcd-backup-pvc/MAINTENANCE.md
@@ -13,12 +13,12 @@ References:
 - [https://github.com/etcd-io/etcd/blob/3c916bb2587174008054f629d784514abe9e8d36/api/etcdserverpb/rpc.pb.go#L7549](api/etcdserverpb/rpc.pb.go)
 
 The main logic of the backup and the snapshot is implemented in the `init.sh`
-file, in the [`etcd-backupper` image](https://github.com/sighupio/fury-distribution-container-image-sync/tree/main/modules/dr/custom/etcd-backupper).
+file, in the [`etcd-backupper` image](https://github.com/sighupio/container-image-sync/tree/main/modules/dr/custom/etcd-backupper).
 
 ## Upgrade checklist
 In order to update and maintain the package:
 - First check if a new image is available for `rclone`
-- Check if another version of Alpine or `etcdctl` is available and update the [custom built `etcd-backupper` image](https://github.com/sighupio/fury-distribution-container-image-sync/tree/main/modules/dr/custom/etcd-backupper)
+- Check if another version of Alpine or `etcdctl` is available and update the [custom built `etcd-backupper` image](https://github.com/sighupio/container-image-sync/tree/main/modules/dr/custom/etcd-backupper)
 - (Optional) Sync the new rclone image to our registry
 - (Optional) Update the images tags in the kustomization.yaml file
 - (Optional) Fix manifest deprecations

--- a/katalog/etcd-backup-s3/MAINTENANCE.md
+++ b/katalog/etcd-backup-s3/MAINTENANCE.md
@@ -13,12 +13,12 @@ References:
 - [https://github.com/etcd-io/etcd/blob/3c916bb2587174008054f629d784514abe9e8d36/api/etcdserverpb/rpc.pb.go#L7549](api/etcdserverpb/rpc.pb.go)
 
 The main logic of the backup and the snapshot is implemented in the `init.sh`
-file, in the [`etcd-backupper` image](https://github.com/sighupio/fury-distribution-container-image-sync/tree/main/modules/dr/custom/etcd-backupper).
+file, in the [`etcd-backupper` image](https://github.com/sighupio/container-image-sync/tree/main/modules/dr/custom/etcd-backupper).
 
 ## Upgrade checklist
 In order to update and maintain the package:
 - First check if a new image is available for `rclone`
-- Check if another version of Alpine or `etcdctl` is available and update the [custom built `etcd-backupper` image](https://github.com/sighupio/fury-distribution-container-image-sync/tree/main/modules/dr/custom/etcd-backupper)
+- Check if another version of Alpine or `etcdctl` is available and update the [custom built `etcd-backupper` image](https://github.com/sighupio/container-image-sync/tree/main/modules/dr/custom/etcd-backupper)
 - (Optional) Sync the new rclone image to our registry
 - (Optional) Update the images tags in the kustomization.yaml file
 - (Optional) Fix manifest deprecations

--- a/katalog/velero/README.md
+++ b/katalog/velero/README.md
@@ -12,7 +12,7 @@
     - [Velero Node Agent](#velero-node-agent)
     - [Velero schedule](#velero-schedule)
 
-<!-- <KFD-DOCS> -->
+<!-- <SKD-DOCS> -->
 
 Velero *(formerly Heptio Ark)* gives you tool to back up and restore your Kubernetes cluster resources and persistent
 volumes. You can run Velero with a cloud provider or on-premises. Velero lets you:
@@ -30,7 +30,7 @@ Velero consists of:
 
 Velero requires to have already deployed the [prometheus-operator](https://github.com/coreos/prometheus-operator) CRDs
 as this feature deploys [a `ServiceMonitor` definition](velero-base/serviceMonitor.yaml). It can be deployed using the
-[fury-kubernetes-monitoring](https://github.com/sighupio/fury-kubernetes-monitoring) KFD core module.
+[skd-monitoring](https://github.com/sighupio/module-monitoring) SKD core module.
 
 ## Server deployment
 
@@ -192,4 +192,4 @@ bases:
   - vendor/katalog/dr/velero/snapshot-controller
 ```
 
-<!-- </KFD-DOCS> -->
+<!-- </SKD-DOCS> -->

--- a/katalog/velero/velero-aws/README.md
+++ b/katalog/velero/velero-aws/README.md
@@ -20,7 +20,7 @@ This deployment requires to have previously created the following resources:
 
 ### Cloud Credentials
 
-This Fury Core module contains [a terraform module](../../../modules/aws-velero) designed to generate every file needed
+This SIGHUP Distribution Core module contains [a terraform module](../../../modules/aws-velero) designed to generate every file needed
 by this deployment including the Cloud Credentials file.
 
 ```bash

--- a/katalog/velero/velero-azure/README.md
+++ b/katalog/velero/velero-azure/README.md
@@ -20,7 +20,7 @@ This deployment requires to have previously created the following resources:
 
 ### Cloud Credentials
 
-This Fury Core module contains [a terraform module](../../../modules/azure-velero) designed to generate every file needed
+This SIGHUP Distribution Core module contains [a terraform module](../../../modules/azure-velero) designed to generate every file needed
 by this deployment including the Cloud Credentials file.
 
 ```bash

--- a/katalog/velero/velero-gcp/README.md
+++ b/katalog/velero/velero-gcp/README.md
@@ -20,7 +20,7 @@ This deployment requires to have previously created the following resources:
 
 ### Cloud Credentials
 
-This Fury Core module contains [a terraform module](../../../modules/gcp-velero) designed to generate every file needed
+This SIGHUP Distribution Core module contains [a terraform module](../../../modules/gcp-velero) designed to generate every file needed
 by this deployment including the Cloud Credentials file.
 
 ```bash


### PR DESCRIPTION
### Summary 💡

The goal of this PR is to rebrand KFD to SIGHUP Distribution (SKD).

### Todo List

- [x] Update all references of Fury distribution to `SKD` or SIGHUP Distribution (didn't touch any code or config)
- [x] Add new logo

### Tests performed 🧪
No tests are needed.