### PR TITLE
fix: set default BackupStorageLocation explicitly

### DIFF
--- a/katalog/velero/velero-on-prem/storageLocation.yaml
+++ b/katalog/velero/velero-on-prem/storageLocation.yaml
@@ -10,6 +10,7 @@ metadata:
     k8s-app: velero
   name: default
 spec:
+  default: true
   config:
     region: minio
     s3ForcePathStyle: "true"


### PR DESCRIPTION
### Summary 💡

Make the default BackupStorageLocation the explicit default instead of relying on Velero heuristics so Velero won't be logging a misleading error that there's no default location.

Fixes #90


### Description 📝

See summary

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested on a 1.32 on-prem cluster.

### Future work 🔧

None